### PR TITLE
Docs: Correct the auro-radio references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ Any update to the Auro Design Tokens will be immediately reflected with browsers
 
 ### Define dependency in project component
 
-Defining the component dependency within each component that is using the `<auro-checkbox>` component.
+Defining the component dependency within each component that is using the `<auro-radio>` component.
 
 ```javascript
-import "@alaskaairux/auro-checkbox";
-import "@alaskaairux/auro-checkbox/dist/auro-checkbox-group";
+import "@alaskaairux/auro-radio";
+import "@alaskaairux/auro-radio/dist/auro-radio-group";
 ```
 
 **Reference component in HTML**
 
 ```html
-<auro-checkbox-group>
-  <auro-checkbox></auro-checkbox>
-</auro-checkbox-group>
+<auro-radio-group>
+  <auro-radio></auro-radio>
+</auro-radio-group>
 ```
 
 ## Install bundled assets from CDN
@@ -61,9 +61,9 @@ In cases where the project is not able to process JS assets, there are pre-proce
 <link rel="stylesheet" href="https://unpkg.com/@alaskaairux/orion-design-tokens@:version/dist/tokens/CSSTokenProperties.css" />
 <link rel="stylesheet" href="https://unpkg.com/@alaskaairux/orion-web-core-style-sheets@:version/dist/bundled/baseline.css" />
 
-<script src="https://unpkg.com/@alaskaairux/auro-checkbox@:version/dist/polyfills.js"></script>
-<script src="https://unpkg.com/@alaskaairux/auro-checkbox@:version/dist/auro-checkbox__bundled.js"></script>
-<script src="https://unpkg.com/@alaskaairux/auro-checkbox@:version/dist/auro-checkbox-group__bundled.js"></script>
+<script src="https://unpkg.com/@alaskaairux/auro-radio@:version/dist/polyfills.js"></script>
+<script src="https://unpkg.com/@alaskaairux/auro-radio@:version/dist/auro-radio__bundled.js"></script>
+<script src="https://unpkg.com/@alaskaairux/auro-radio@:version/dist/auro-radio-group__bundled.js"></script>
 ```
 
 ### polyfills.js
@@ -98,4 +98,4 @@ $ npm run serve
 Open [localhost:3001](http://localhost:3001/)
 
 ### Testing
-Automated tests are required for every Auro component. See `.\test\auro-checkbox.test.js` for the tests for this component. Run `npm test` to run the tests and check code coverage. Tests must pass and meet a certain coverage threshold to commit. See [the testing documentation](https://github.com/AlaskaAirlines/auro_docs/blob/master/src/TESTS.md) for more details.
+Automated tests are required for every Auro component. See `.\test\auro-radio.test.js` for the tests for this component. Run `npm test` to run the tests and check code coverage. Tests must pass and meet a certain coverage threshold to commit. See [the testing documentation](https://github.com/AlaskaAirlines/auro_docs/blob/master/src/TESTS.md) for more details.


### PR DESCRIPTION
# #Change auro-checkbox references to be auro-radio

# Alaska Airlines Pull Request

This PR corrects the docs for the auro-radio button. 

**Fixes:** #2 
Prior to these changes, there were references to the auro-checkbox in the README for the auro-radio. This caused some confusion and potential bugs. For example, if a developer tried to include a reference to the auro-radio cdn bundle in a web page. 

## Summary:

This is a documentation change only. It will correct the references to auro-checkbox that exist in this repo's docs.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
