### PR TITLE
feat: support disabling individual auro-radio components within an auro-radio-group

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -264,7 +264,7 @@
               label="Maybe"
               name="radioDemo5"
               value="maybe"
-            ></auro-radio>
+          ></auro-radio>
           </auro-radio-group>
         </template>
       </demo-snippet>
@@ -294,6 +294,20 @@
               value="maybe"
             ></auro-radio>
           </auro-radio-group>
+        </template>
+      </demo-snippet>
+
+      <p>Individual Radio buttons set <code>disabled</code></p>
+      <demo-snippet>
+        <template>
+            <auro-radio-group required>
+              <span slot="legend">Will you pick a plan?</span>
+              <auro-radio id="radio22" label="Yes" name="radioDemo7" value="yes" disabled></auro-radio>
+              <auro-radio id="radio23" label="No" name="radioDemo7" value="no"></auro-radio>
+              <auro-radio id="radio24" label="Definitely" name="radioDemo7" value="definitely" disabled></auro-radio>
+              <auro-radio id="radio25" label="Maybe" name="radioDemo7" value="maybe" ></auro-radio>
+              <auro-radio id="radio26" label="Probably" name="radioDemo7" value="probably"></auro-radio>
+            </auro-radio-group>
         </template>
       </demo-snippet>
 

--- a/test/auro-radio.test.js
+++ b/test/auro-radio.test.js
@@ -432,6 +432,216 @@ describe('auro-radio-group', () => {
 
     expect(el.items.length).to.equal(0);
   });
+
+  it('supports individual radio buttons being disabled in a group', async () => {
+    const el = await fixture(html`
+      <auro-radio-group
+      >
+        <auro-radio
+          id="alaska"
+          label="Alaska"
+          name="states"
+          value="alaska"
+        ></auro-radio>
+
+        <auro-radio
+          id="washington"
+          label="Washington"
+          name="states"
+          value="washington"
+          checked
+        ></auro-radio>
+
+        <auro-radio
+          id="california"
+          label="California"
+          name="states"
+          value="california"
+          disabled
+        ></auro-radio>
+
+        <auro-radio
+        id="wisconsin"
+        label="Wisconsin"
+        name="states"
+        value="wisconsin"
+        disabled
+      ></auro-radio>
+      </auro-radio-group>
+    `);
+
+    const alaskaRadio = el.querySelector("auro-radio[id=alaska]");
+    const washingtonRadio = el.querySelector("auro-radio[id=washington]");
+    const californiaRadio = el.querySelector("auro-radio[id=california]");
+    const wisconsinRadio = el.querySelector("auro-radio[id=wisconsin]");
+
+    expect(alaskaRadio.checked).to.not.be.true;
+    expect(washingtonRadio.checked).to.be.true;
+    expect(californiaRadio.checked).to.not.be.true;
+    expect(wisconsinRadio.checked).to.not.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Down"}));
+
+    await elementUpdated(el);
+
+    expect(alaskaRadio.checked, "Alaska Radio should be false").to.not.be.true;
+    expect(washingtonRadio.checked, "Washington Radio should be true").to.be.true;
+    expect(californiaRadio.checked, "California Radio should be false").to.not.be.true;
+    expect(wisconsinRadio.checked, "Wisconsin Radio should be false").to.not.be.true;
+    expect(californiaRadio.disabled, "California Radio should be disabled").to.be.true;
+    expect(wisconsinRadio.disabled, "Wisconsin Radio should be disabled").to.be.true;
+  });
+
+  it('disabled radio buttons in a group are skipped over on keydown events', async () => {
+    const el = await fixture(html`
+      <auro-radio-group
+      >
+        <auro-radio
+          id="alaska"
+          label="Alaska"
+          name="states"
+          value="alaska"
+          disabled
+        ></auro-radio>
+
+        <auro-radio
+          id="washington"
+          label="Washington"
+          name="states"
+          value="washington"
+          checked
+        ></auro-radio>
+
+        <auro-radio
+          id="california"
+          label="California"
+          name="states"
+          value="california"
+          disabled
+        ></auro-radio>
+
+        <auro-radio
+        id="wisconsin"
+        label="Wisconsin"
+        name="states"
+        value="wisconsin"
+      ></auro-radio>
+
+      <auro-radio
+        id="oregon"
+        label="Oregon"
+        name="states"
+        value="oregon"
+      ></auro-radio>
+      </auro-radio-group>
+    `);
+
+    const alaskaRadio = el.querySelector("auro-radio[id=alaska]");
+    const washingtonRadio = el.querySelector("auro-radio[id=washington]");
+    const californiaRadio = el.querySelector("auro-radio[id=california]");
+    const wisconsinRadio = el.querySelector("auro-radio[id=wisconsin]");
+    const oregonRadio = el.querySelector("auro-radio[id=oregon]");
+
+    expect(alaskaRadio.checked).to.not.be.true;
+    expect(washingtonRadio.checked).to.be.true;
+    expect(californiaRadio.checked).to.not.be.true;
+    expect(wisconsinRadio.checked).to.not.be.true;
+    expect(oregonRadio.checked).to.not.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Down"}));
+
+    await elementUpdated(el);
+
+    expect(alaskaRadio.checked, "Alaska Radio should be false").to.not.be.true;
+    expect(washingtonRadio.checked, "Washington Radio should be false").to.not.true;
+    expect(californiaRadio.checked, "California Radio should be false").to.not.be.true;
+    expect(wisconsinRadio.checked, "Wisconsin Radio should be true").to.be.true;
+    expect(oregonRadio.checked, "Oregon Radio should be false").to.not.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Down"}));
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Down"}));
+
+    await elementUpdated(el);
+
+    expect(alaskaRadio.checked, "Alaska Radio should be false").to.not.be.true;
+    expect(washingtonRadio.checked, "Washington Radio should be true").to.be.true;
+    expect(californiaRadio.checked, "California Radio should be false").to.not.be.true;
+    expect(wisconsinRadio.checked, "Wisconsin Radio should be false").to.not.be.true;
+    expect(oregonRadio.checked, "Oregon Radio should be false").to.not.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Up"}));
+
+    await elementUpdated(el);
+
+    expect(alaskaRadio.checked, "Alaska Radio should be false").to.not.be.true;
+    expect(washingtonRadio.checked, "Washington Radio should be false").to.not.be.true;
+    expect(californiaRadio.checked, "California Radio should be false").to.not.be.true;
+    expect(wisconsinRadio.checked, "Wisconsin Radio should be false").to.not.be.true;
+    expect(oregonRadio.checked, "Oregon Radio should be true").to.be.true;
+  });
+
+  it('Supports all radio buttons being set to disabled if the group is disabled, even if some individual components are not explicitly set to disabled', async () => {
+    const el = await fixture(html`
+      <auro-radio-group
+      disabled
+      >
+        <auro-radio
+          id="alaska"
+          label="Alaska"
+          name="states"
+          value="alaska"
+        ></auro-radio>
+
+        <auro-radio
+          id="washington"
+          label="Washington"
+          name="states"
+          value="washington"
+          checked
+        ></auro-radio>
+
+        <auro-radio
+          id="california"
+          label="California"
+          name="states"
+          value="california"
+          disabled
+        ></auro-radio>
+
+        <auro-radio
+        id="wisconsin"
+        label="Wisconsin"
+        name="states"
+        value="wisconsin"
+        disabled
+      ></auro-radio>
+      </auro-radio-group>
+    `);
+
+    const alaskaRadio = el.querySelector("auro-radio[id=alaska]");
+    const washingtonRadio = el.querySelector("auro-radio[id=washington]");
+    const californiaRadio = el.querySelector("auro-radio[id=california]");
+    const wisconsinRadio = el.querySelector("auro-radio[id=wisconsin]");
+
+    expect(alaskaRadio.checked).to.not.be.true;
+    expect(washingtonRadio.checked).to.be.true;
+    expect(californiaRadio.checked).to.not.be.true;
+    expect(wisconsinRadio.checked).to.not.be.true;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', {key: "Down"}));
+
+    await elementUpdated(el);
+
+    expect(alaskaRadio.checked, "Alaska Radio should be false").to.not.be.true;
+    expect(washingtonRadio.checked, "Washington Radio should be true").to.be.true;
+    expect(californiaRadio.checked, "California Radio should be false").to.not.be.true;
+    expect(wisconsinRadio.checked, "Wisconsin Radio should be false").to.not.be.true;
+
+    expect(alaskaRadio.disabled, "Alaska Radio should be true").to.be.true;
+    expect(washingtonRadio.disabled, "Washington Radio should be true").to.be.true;
+    expect(californiaRadio.disabled, "California Radio should be disabled").to.be.true;
+    expect(wisconsinRadio.disabled, "Wisconsin Radio should be disabled").to.be.true;
+  });
 });
 
 describe('auro-radio', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

As a developer, I want to offer a radio group which allows for individual auro-radio components to be disabled without having to disable the entire auro radio-group.

## Summary:

Prior to this feature addition, the auro-radio-group only allowed for disabling the entire radio group. This PR adds support for having a radio group with one or more individual radio buttons disabled, as seen here: 
![image](https://user-images.githubusercontent.com/17755678/96049499-f5325b00-0e2c-11eb-843f-d6ea8ad99747.png)


## Type of change:

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
