### PR TITLE
fix: fix focus outline in high-contrast mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,13 +24,25 @@
       }
     },
     "@alaskaairux/orion-web-core-style-sheets": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-web-core-style-sheets/-/orion-web-core-style-sheets-2.9.4.tgz",
-      "integrity": "sha512-CTdpAI33vQyLHCxKgMso/C6dcj53ByYAYeDx7dX0SKUNetMtLXbOf/T37AOhH/gGQSC+ME0fql9VgLRI8esT/Q==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/orion-web-core-style-sheets/-/orion-web-core-style-sheets-2.12.1.tgz",
+      "integrity": "sha512-y8liI9oYMldC6opSzYLCYmK8HHlMEJQ/aSFktm/TJlWk1TfSRWOtRKLuya3gYIAULznIFKXEhi+1rK9lY71lcA==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0",
+        "chalk": "^4.1.0",
         "focus-visible": "^5.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {

--- a/src/auro-radio.scss
+++ b/src/auro-radio.scss
@@ -38,6 +38,7 @@
   .rdoGroup {
     display: block;
     background-color: var(--auro-color-ui-default-on-light);
+    outline: 3px solid transparent; // for Windows High Contrast mode
     padding-right: var(--auro-size-xs);
 
     .rdo--input {
@@ -83,7 +84,6 @@
 
     & + .label {
       &:after {
-        // opacity: 1;
         border-color: var(--auro-color-ui-default-on-light);
         box-shadow: inset 0 0 0 var(--shadow-inset) var(--auro-color-base-white);
         background-color: var(--auro-color-ui-default-on-light);


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

Add a focus outline when tabbing in high-contrast mode. Since the focus indicator used a background color, this was not visible when using Windows High-Contrast Mode.

Before:
![image](https://user-images.githubusercontent.com/4992896/98727091-3d6d6c00-234c-11eb-88bf-06de3c0db406.png)

After:
![image](https://user-images.githubusercontent.com/4992896/98726992-19aa2600-234c-11eb-8cbb-16042da4747e.png)

This is not dependent on the WCSS change because the element being focused did not have any default focus styles.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
