### PR TITLE
Make individual error prop a boolean and sync child state with parent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-radio",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -51,6 +51,32 @@ class AuroRadioGroup extends LitElement {
     this.addEventListener('resetRadio', this.reset);
   }
 
+  /**
+   * LitElement lifecycle method. Called after the DOM has been updated.
+   * @param {Map<string, any>} changedProperties - keys are the names of changed properties, values are the corresponding previous values.
+   * @returns {void}
+   */
+  updated(changedProperties) {
+    if (changedProperties.has('disabled')) {
+      // only change the children if we are making everything disabled, or if we are making everything enabled and there are no individually-disabled radio buttons
+      if (this.disabled || this.items.every((el) => el.disabled)) {
+        this.items.forEach((el) => {
+          el.disabled = this.disabled
+        });
+      }
+    }
+    if (changedProperties.has('required')) {
+      this.items.forEach((el) => {
+        el.required = this.required
+      });
+    }
+    if (changedProperties.has('error')) {
+      this.items.forEach((el) => {
+        el.error = Boolean(this.error)
+      });
+    }
+  }
+
   reset() {
     this.items.forEach((item) => {
       item.tabIndex = -1;
@@ -69,7 +95,8 @@ class AuroRadioGroup extends LitElement {
     }
 
     this.items.forEach((el) => {
-      el.required = this.required
+      el.required = this.required;
+      el.error = Boolean(this.error);
     });
   }
 
@@ -91,7 +118,6 @@ class AuroRadioGroup extends LitElement {
   }
 
   handleToggleSelected(event) {
-
     this.index = this.items.indexOf(event.target);
 
     this.items.forEach((item) => {
@@ -105,12 +131,6 @@ class AuroRadioGroup extends LitElement {
         item.tabIndex = -1;
       }
     })
-  }
-
-  errorChange() {
-    this.items.forEach((el) => {
-      el.error = Boolean(this.error)
-    });
   }
 
   selectItem(index) {
@@ -170,8 +190,6 @@ class AuroRadioGroup extends LitElement {
     }
 
     return html`
-      ${this.errorChange()}
-
       <fieldset class="${classMap(groupClasses)}">
         ${this.required
         ? html`<legend><slot name="legend"></slot></legend>`

--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -17,6 +17,9 @@ class AuroRadioGroup extends LitElement {
     super();
     this.index = 0;
     this.max = 3;
+    this.disabled = false;
+    this.horizontal = false;
+    this.required = false;
   }
 
   static get styles() {
@@ -27,10 +30,16 @@ class AuroRadioGroup extends LitElement {
 
   static get properties() {
     return {
-      disabled:   { type: Boolean },
+      disabled:   {
+        type: Boolean,
+        reflect: true
+      },
       horizontal: { type: Boolean },
       required:   { type: Boolean },
-      error:      { type: String },
+      error:      {
+        type: String,
+        reflect: true
+       },
     };
   }
 

--- a/src/auro-radio.js
+++ b/src/auro-radio.js
@@ -19,6 +19,7 @@ class AuroRadio extends LitElement {
     this.checked = false;
     this.disabled = false;
     this.required = false;
+    this.error = false;
     this.tabIndex = -1;
   }
 
@@ -44,7 +45,7 @@ class AuroRadio extends LitElement {
         reflect: true
       },
       error: {
-        type: String,
+        type: Boolean,
         reflect: true
       },
       id:       { type: String },
@@ -114,7 +115,7 @@ class AuroRadio extends LitElement {
       'ods-inputLabel--radio': true,
       'label': true,
       'label--rdo': true,
-      'errorBorder': Boolean(this.error)
+      'errorBorder': this.error
     }
 
     return html`

--- a/src/auro-radio.js
+++ b/src/auro-radio.js
@@ -18,6 +18,7 @@ class AuroRadio extends LitElement {
     super();
     this.checked = false;
     this.disabled = false;
+    this.required = false;
     this.tabIndex = -1;
   }
 
@@ -130,7 +131,7 @@ class AuroRadio extends LitElement {
           id="${ifDefined(this.id)}"
           name="${ifDefined(this.name)}"
           type="radio"
-          .value="${ifDefined(this.value)}"
+          .value="${this.value}"
           tabIndex="-1"
         />
 

--- a/src/auro-radio.scss
+++ b/src/auro-radio.scss
@@ -25,7 +25,7 @@
   outline: unset;
 }
 
-:host([error='true']) {
+:host([error]) {
   color: var(--auro-color-text-error-on-light);
 }
 

--- a/test/auro-radio.test.js
+++ b/test/auro-radio.test.js
@@ -691,6 +691,32 @@ describe('auro-radio-group', () => {
     expect(washingtonRadio.checked, "Washington Radio Button Clicked: Checked").to.be.true;
   });
 
+  it('sets child state after slot change', async () => {
+    const el = await fixture(html`<auro-radio-group label="Select your state of residence" disabled required error="Something went wrong"></auro-radio-group>`);
+
+    // render radio children after the group has connected
+    await fixture(html`
+      <auro-radio
+      id="alaska"
+      label="Alaska"
+      name="states"
+      value="alaska"
+    ></auro-radio>
+    <auro-radio
+      id="washington"
+      label="Washington"
+      name="states"
+      value="washington"
+    ></auro-radio>
+    `, { parentNode: el });
+
+    const radio = el.querySelector('auro-radio');
+
+    expect(radio.disabled).to.be.true;
+    expect(radio.required).to.be.true;
+    expect(radio.error).to.be.true;
+  });
+
   it('sets error on child radios', async () => {
     const el = await fixture(html`
       <auro-radio-group
@@ -714,7 +740,40 @@ describe('auro-radio-group', () => {
 
     const radio = el.querySelector('auro-radio');
 
-    expect(radio.error).to.be.true;
+    expect(radio.error, "child error state was not updated").to.be.true;
+  });
+
+  it('updates states on children', async () => {
+    const el = await fixture(html`
+      <auro-radio-group
+        label="Select your favorite states"
+      >
+        <auro-radio
+          id="alaska"
+          label="Alaska"
+          name="states"
+          value="alaska"
+        ></auro-radio>
+        <auro-radio
+          id="washington"
+          label="Washington"
+          name="states"
+          value="washington"
+        ></auro-radio>
+      </auro-radio-group>
+    `);
+
+    el.disabled = true;
+    el.required = true;
+    el.error = "Something went wrong";
+
+    await elementUpdated(el);
+
+    const radio = el.querySelector('auro-radio');
+
+    expect(radio.disabled, "child disabled state was not updated").to.be.true;
+    expect(radio.required, "child required state was not updated").to.be.true;
+    expect(radio.error, "child error state was not updated").to.be.true;
   });
 });
 
@@ -749,6 +808,7 @@ describe('auro-radio', () => {
     expect(input.name).to.equal(expectedName);
     expect(input.type).to.equal('radio');
     expect(input.getAttribute('aria-invalid')).to.equal('true');
+    expect(input.getAttribute('aria-required')).to.equal('true');
     expect(errorBorder).to.not.be.undefined;
     expect(el).dom.to.equal(`
     <auro-radio id="${expectedId}" tabindex="-1" name="${expectedName}" value="${expectedValue}" error checked disabled required>

--- a/test/auro-radio.test.js
+++ b/test/auro-radio.test.js
@@ -689,7 +689,33 @@ describe('auro-radio-group', () => {
     // and the first radio button should be `unchecked`
     expect(alaskaRadio.checked, "Alaska Radio Button Unchecked (Washington Clicked)").to.not.be.true;
     expect(washingtonRadio.checked, "Washington Radio Button Clicked: Checked").to.be.true;
-  })
+  });
+
+  it('sets error on child radios', async () => {
+    const el = await fixture(html`
+      <auro-radio-group
+        label="Select your favorite states"
+        error="Wrong entry"
+      >
+        <auro-radio
+          id="alaska"
+          label="Alaska"
+          name="states"
+          value="alaska"
+        ></auro-radio>
+        <auro-radio
+          id="washington"
+          label="Washington"
+          name="states"
+          value="washington"
+        ></auro-radio>
+      </auro-radio-group>
+    `);
+
+    const radio = el.querySelector('auro-radio');
+
+    expect(radio.error).to.be.true;
+  });
 });
 
 describe('auro-radio', () => {
@@ -697,7 +723,6 @@ describe('auro-radio', () => {
     const expectedId = "testId",
       expectedName = "testName",
       expectedValue = "testValue",
-      expectedError = "testError",
       expectedTabIndex = -1;
 
     const el = await fixture(html`
@@ -708,7 +733,7 @@ describe('auro-radio', () => {
         checked
         disabled
         required
-        error=${expectedError}
+        error
       ></auro-radio>
     `);
 
@@ -723,9 +748,10 @@ describe('auro-radio', () => {
     expect(input.value).to.equal(expectedValue);
     expect(input.name).to.equal(expectedName);
     expect(input.type).to.equal('radio');
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
     expect(errorBorder).to.not.be.undefined;
     expect(el).dom.to.equal(`
-    <auro-radio id="${expectedId}" tabindex="-1" name="${expectedName}" value="${expectedValue}" error="${expectedError}" checked disabled required>
+    <auro-radio id="${expectedId}" tabindex="-1" name="${expectedName}" value="${expectedValue}" error checked disabled required>
     </auro-radio>`);
   });
 });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #33
Fixes #49
Fixes #50

## Summary:

- The `error` property on individual radios is now a boolean in line with existing documentation
- When the parent's disabled or required state updates, the children are also updated using the [updated lifecycle](https://lit.dev/docs/components/lifecycle/#updated) method.
- Refactor existing error state handling to use the above method.
- Set error state when a new item is added to the slot.
- Reflect styling hooks and set default values for booleans.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
