### PR TITLE
fix(group): initialize items before resetting #57

### DIFF
--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -78,6 +78,9 @@ class AuroRadioGroup extends LitElement {
   }
 
   reset() {
+    if (this.items.length === 0) {
+      this.handleItems();
+    }
     this.items.forEach((item) => {
       item.tabIndex = -1;
     })

--- a/test/auro-radio.test.js
+++ b/test/auro-radio.test.js
@@ -691,6 +691,39 @@ describe('auro-radio-group', () => {
     expect(washingtonRadio.checked, "Washington Radio Button Clicked: Checked").to.be.true;
   });
 
+  it('handles reset firing before all items initialized', async () => {
+    const el = await fixture(html`<auro-radio-group label="Select your state of residence" required></auro-radio-group>`);
+
+    // render radio children after the group has connected
+    // this is intentionally not awaited
+    const renderChildren = fixture(html`
+      <auro-radio
+      id="alaska"
+      label="Alaska"
+      name="states"
+      value="alaska"
+    ></auro-radio>
+    <auro-radio
+      id="washington"
+      label="Washington"
+      name="states"
+      value="washington"
+    ></auro-radio>
+    `, { parentNode: el });
+
+    // simulate the reset event firing before items are fully initialized
+    // this is a little contrived, but happens when the radio-group is rendered in Svelte
+    // we want to make sure this does not throw an error if the items are not set yet
+    el.reset();
+
+    // finally, wait for everything to finish updating
+    await renderChildren;
+
+    // verify that child state was updated
+    const radio = el.querySelector("auro-radio");
+    expect(radio.required).to.be.true;
+  });
+
   it('sets child state after slot change', async () => {
     const el = await fixture(html`<auro-radio-group label="Select your state of residence" disabled required error="Something went wrong"></auro-radio-group>`);
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #57

## Summary:

This makes sure `this.items` is initialized before resetting the radio group. In a Svelte app, this was consistently happening. I'm not sure why, but somehow the individual items "reset" event was being fired before the "slotchange" event that initializes the group. I added a test that failed before this change -- it's not quite the same scenario, but captures the same behavior.

I tested this change inside AuroSvelteDemo and it fixes the error.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
