### PR TITLE
fix(disabled ui): loop safe check when disabled #105

### DIFF
--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -293,6 +293,10 @@ class AuroRadioGroup extends LitElement {
       currIndex = currIndex === -1 ? this.items.length - 1 : currIndex;
       const sdItem = this.items[currIndex].shadowRoot.querySelector('input');
 
+      if (this.disabled || this.items.every((item) => item.disabled === true)) {
+        sdItem.focus();
+        break;
+      }
       if (!sdItem.disabled) {
         sdItem.click();
         sdItem.focus();


### PR DESCRIPTION
# Alaska Airlines Pull Request

This is a safe check so we do not enter an infinite loop when a radio group is disabled and we push key "up"

this is the current state when we push arrow "up" on a disabled auro-radio-group:

![image](https://user-images.githubusercontent.com/108018885/234408708-71224edc-fa21-435f-b2cf-b3c4cd12b1b1.png)


**Fixes:** #105 
## Summary:

This changes affect the disabled button and do not disrupt current functionality.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)
- [X] bug


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
