### PR TITLE
Feature radio group css part

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -365,19 +365,19 @@
             <auro-radio
               id="radio27"
               label="Yes"
-              name="radioDemo1"
+              name="radioDemo8"
               value="yes"
             ></auro-radio>
             <auro-radio
               id="radio28"
               label="No"
-              name="radioDemo1"
+              name="radioDemo8"
               value="no"
             ></auro-radio>
             <auro-radio
               id="radio29"
               label="Maybe"
-              name="radioDemo1"
+              name="radioDemo8"
               value="maybe"
             ></auro-radio>
           </auro-radio-group>

--- a/demo/index.html
+++ b/demo/index.html
@@ -348,6 +348,42 @@
         </template>
       </demo-snippet>
 
+      <p>Radio button group, <code>radio-group</code> css part in blue</p>
+      <demo-snippet>
+        <template>
+          <style>
+            .example::part(radio-group) {
+              background-color: lightblue;
+            }
+            .example {
+              background-color: lightgrey;
+            }
+          </style>
+      
+          <auro-radio-group class="example">
+            <span slot="legend">Form label goes here</span>
+            <auro-radio
+              id="radio27"
+              label="Yes"
+              name="radioDemo1"
+              value="yes"
+            ></auro-radio>
+            <auro-radio
+              id="radio28"
+              label="No"
+              name="radioDemo1"
+              value="no"
+            ></auro-radio>
+            <auro-radio
+              id="radio29"
+              label="Maybe"
+              name="radioDemo1"
+              value="maybe"
+            ></auro-radio>
+          </auro-radio-group>
+        </template>
+      </demo-snippet>
+
     </div>
   </body>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,3 +26,9 @@
 |-----------|--------------------------------------------|
 |  | Places content into the `label` element; will override content from the `label` attribute |
 | `content` | Additional content element within the scope of the custom element; will not highlight with tab focus  |
+
+## CSS Shadow Parts
+
+| Part | Description |
+|------|-------------|
+| `radio-group` | Adjust styling of the radio-group fieldset |

--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -21,6 +21,7 @@ import styleCss from "./auro-radio-group-css.js";
  * @attr {String} error - When defined, sets persistent validity to `customError` and sets `setCustomValidity` = attribute value.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} required - Populates the `required` attribute on the element. Used for client-side validation.
+ * @csspart radio-group - Adjust styling of the radio-group fieldset
  */
 
 class AuroRadioGroup extends LitElement {
@@ -339,7 +340,7 @@ class AuroRadioGroup extends LitElement {
     }
 
     return html`
-      <fieldset class="${classMap(groupClasses)}">
+      <fieldset class="${classMap(groupClasses)}" part="radio-group">
         ${this.required
         ? html`<legend><slot name="legend"></slot></legend>`
         : html`<legend><slot name="legend"></slot> (optional)</legend>`


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adds `radio-group` css part. This part allows for the fieldset to be accessed in the shadow dom.

This change was initiated as part of a bug reported for [Remove spacing below radio group](https://github.com/AlaskaAirlines/auro-radio/issues/103). After it was determined that the issue was not a bug, it was decided to add a new feature to support accessing the radio group within the shadow dom.

**Fixes:** # (issue, if applicable)
Related to [Remove spacing below radio group](https://github.com/AlaskaAirlines/auro-radio/issues/103). 
Note: The initial bug request to remove the spacing below the radio group can be completed without adjusting the `radio-group` css part in the shadow dom.

## Summary:

Add support for customizing radio-group.

## Type of change:

Please delete options that are not relevant.

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
