### PR TITLE
feat(api): add register static method

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -44,10 +44,8 @@
       import { AuroRadio } from '../src/auro-radio.js';
       import { AuroRadioGroup } from '../src/auro-radio-group.js';
 
-      import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
-
-      RuntimeUtils.default.prototype.registerComponent('custom-radio', AuroRadio);
-      RuntimeUtils.default.prototype.registerComponent('custom-radio-group', AuroRadioGroup);
+      AuroRadio.register('custom-radio');
+      AuroRadioGroup.register('custom-radio-group');
     </script>
 
     <!-- If additional elements are needed for the demo, add them here. -->

--- a/demo/index.md
+++ b/demo/index.md
@@ -80,21 +80,25 @@ This is a default configuration using the `<auro-radio-group>` and `<auro-radio>
 
 There are two important parts of every Auro component. The <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">class</a> and the custom clement. The class is exported and then used as part of defining the Web Component. When importing this component as described in the <a href="#install">install</a> section, the class is imported and the `<auro-radio>` custom element is defined automatically.
 
-To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our `registerComponent(name)` method and pass in a unique name.
+<<<<<<< Updated upstream
+To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our `register(name)` method and pass in a unique name.
+=======
+There are two important parts of every Auro component. The <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">class</a> and the custom clement. The class is exported and then used as part of defining the Web Component. When importing this component as described in the <a href="#install">install</a> section, the class is imported and the `<auro-radio>` custom element is defined automatically.
+
+To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our static `register(name)` method on the component class and pass in a unique name.
+>>>>>>> Stashed changes
 
 ```js
 import { AuroRadio } from './src/auro-radio.js';
 import { AuroRadioGroup } from './src/auro-radio-group.js';
 
-import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
-
-RuntimeUtils.default.prototype.registerComponent('custom-radio', AuroRadio);
-RuntimeUtils.default.prototype.registerComponent('custom-radio-group', AuroRadioGroup);
+AuroRadio.register('custom-radio');
+AuroRadioGroup.register('custom-radio-group');
 ```
 
 This will create a new custom element that you can use in your HTML that will function identically to the `<auro-radio>` element.
 
-Using the `registerComponent` function to create a custom `<auro-radio>` will also create a custom `<auro-radio-group>` with the exact same naming convention, ending in "-group". For example, using `registerComponent('custom-radio')` will result in `<custom-radio-group>` also being created.
+Using the `register` function to create a custom `<auro-radio>` will also create a custom `<auro-radio-group>` with the exact same naming convention, ending in "-group". For example, using `AuroRadio.register('custom-radio')` will result in `<custom-radio-group>` also being created.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/customRadio.html) -->

--- a/docs/partials/index.md
+++ b/docs/partials/index.md
@@ -54,21 +54,25 @@ This is a default configuration using the `<auro-radio-group>` and `<auro-radio>
 
 There are two important parts of every Auro component. The <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">class</a> and the custom clement. The class is exported and then used as part of defining the Web Component. When importing this component as described in the <a href="#install">install</a> section, the class is imported and the `<auro-radio>` custom element is defined automatically.
 
-To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our `registerComponent(name)` method and pass in a unique name.
+<<<<<<< Updated upstream
+To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our `register(name)` method and pass in a unique name.
+=======
+There are two important parts of every Auro component. The <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">class</a> and the custom clement. The class is exported and then used as part of defining the Web Component. When importing this component as described in the <a href="#install">install</a> section, the class is imported and the `<auro-radio>` custom element is defined automatically.
+
+To protect from versioning conflicts with other instances of the component being loaded, it is recommended to use our static `register(name)` method on the component class and pass in a unique name.
+>>>>>>> Stashed changes
 
 ```js
 import { AuroRadio } from './src/auro-radio.js';
 import { AuroRadioGroup } from './src/auro-radio-group.js';
 
-import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
-
-RuntimeUtils.default.prototype.registerComponent('custom-radio', AuroRadio);
-RuntimeUtils.default.prototype.registerComponent('custom-radio-group', AuroRadioGroup);
+AuroRadio.register('custom-radio');
+AuroRadioGroup.register('custom-radio-group');
 ```
 
 This will create a new custom element that you can use in your HTML that will function identically to the `<auro-radio>` element.
 
-Using the `registerComponent` function to create a custom `<auro-radio>` will also create a custom `<auro-radio-group>` with the exact same naming convention, ending in "-group". For example, using `registerComponent('custom-radio')` will result in `<custom-radio-group>` also being created.
+Using the `register` function to create a custom `<auro-radio>` will also create a custom `<auro-radio-group>` with the exact same naming convention, ending in "-group". For example, using `AuroRadio.register('custom-radio')` will result in `<custom-radio-group>` also being created.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/customRadio.html) -->

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 import { AuroRadio } from './src/auro-radio.js';
 import { AuroRadioGroup } from './src/auro-radio-group.js';
 
-import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
-
-RuntimeUtils.default.prototype.registerComponent('custom-radio', AuroRadio);
-RuntimeUtils.default.prototype.registerComponent('custom-radio-group', AuroRadioGroup);
+AuroRadio.register();
+AuroRadioGroup.register();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-radio",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-radio",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/auro-radio-group.js
+++ b/src/auro-radio-group.js
@@ -119,6 +119,25 @@ export class AuroRadioGroup extends LitElement {
     };
   }
 
+  /**
+   * This will register this element with the browser
+   * @param {string} [name="auro-radio-group"]
+   *
+   * @example
+<<<<<<< Updated upstream
+   * AuroRadioGroup.register("custom-radio") // this will resgiter this element to <custom-radio/>
+=======
+   * AuroRadioGroup.register("custom-radio") // this will register this element to <custom-radio/>
+>>>>>>> Stashed changes
+   *
+   */
+  static register(name = "auro-radio-group") {
+    // default internal definition
+    if (!customElements.get(name)) {
+      customElements.define(name, AuroRadioGroup);
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.handleItems();
@@ -418,10 +437,4 @@ export class AuroRadioGroup extends LitElement {
       }
     `;
   }
-}
-
-/* istanbul ignore else */
-// define the name of the custom component
-if (!customElements.get("auro-radio-group")) {
-  customElements.define("auro-radio-group", AuroRadioGroup);
 }

--- a/src/auro-radio.js
+++ b/src/auro-radio.js
@@ -83,6 +83,21 @@ export class AuroRadio extends LitElement {
   }
 
   /**
+   * This will register this element with the browser
+   * @param {string} [name="auro-radio"]
+   *
+   * @example
+   * AuroRadio.register("custom-radio") // this will resgiter this element to <custom-radio/>
+   *
+   */
+  static register(name = "auro-radio") {
+    // default internal definition
+    if (!customElements.get(name)) {
+      customElements.define(name, AuroRadio);
+    }
+  }
+
+  /**
    * Method for handling content when change event is fired.
    * @private
    * @param {Event} event - The trigger event tied to this function.
@@ -231,10 +246,4 @@ export class AuroRadio extends LitElement {
       <slot name="content" class="slotContent"></slot>
     `;
   }
-}
-
-/* istanbul ignore else */
-// define the name of the custom component
-if (!customElements.get("auro-radio")) {
-  customElements.define("auro-radio", AuroRadio);
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Resolves:** # (issue, if applicable)

## Summary:

AuroRadio.register is to easily register the element without extra importing 
`import "@aurodesignsystem/auro-radio"` will still register this element to `<auro-radio>` 
`import { AuroRadio } from '../src/auro-radio.js` will NOT register this element until `AuroRadio.register` gets called

Same chages applied to AuroRadioGroup

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add a static register method to AuroRadio and AuroRadioGroup to simplify the registration of custom elements, eliminating the need for RuntimeUtils. Update documentation to guide users on using the new method.

New Features:
- Introduce a static register method for AuroRadio and AuroRadioGroup to allow custom element registration without additional imports.

Enhancements:
- Remove the use of RuntimeUtils for component registration in favor of the new static register method.

Documentation:
- Update documentation to reflect the new static register method for AuroRadio and AuroRadioGroup, replacing previous instructions involving RuntimeUtils.